### PR TITLE
Improve the responsiveness of the map and youtube embeds

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -77,8 +77,9 @@ main {
 }
 
 #map {
-    height: 400px;
+    height: 0;
     width: 100%;
+    padding-bottom: 80%;
 }
 
 #mapBox {
@@ -107,8 +108,19 @@ main {
 }
 
 #topVideo {
-    width: 200px;
-    height: 200px;
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 60%;
+}
+
+#topVideo iframe {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    padding-bottom: 1rem;
 }
 
 #topTrackName, #topPrev, #topNext {
@@ -119,13 +131,11 @@ main {
     .table {
         width: 100%;
     }
+    
     #artistTable td {
         width: 100%;
     }
-    iframe {
-        width: 100%;
-    }
-    
+        
     .footer {
         padding: 1rem 0rem;
     }
@@ -133,10 +143,6 @@ main {
     #mapBox {
         width: 100%;
         flex-grow: 1;
-    }
-
-    #map {
-        height: 500px;
     }
 
     #pageInput {
@@ -150,11 +156,5 @@ main {
     .columns-container {
         display: flex;
         flex-direction: column-reverse;
-    }
-}
-
-@media only screen and (max-width: 500px) {
-    #map {
-        height: 350px;
     }
 }


### PR DESCRIPTION
Map stays square-ish.  Youtube videos stay as large as possible while fitting their container.  simplifies the CSS as well.