### PR TITLE
Make additional api calls to retrieve all results

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -322,7 +322,6 @@ function getLocalEventsPromise() {
 //=====================================================================
 function getAreaEvents(initial = false) {
     // if (initial) location.href = "#heroBlock";
-
     // 1. API REQUEST - Look up the User Location based off IP Address
     // 2. API REQUEST - Find Metro Areas based off Location Data
     // 3. API REQUESTS - Request Event Info from Each Metro Area
@@ -334,11 +333,9 @@ function getAreaEvents(initial = false) {
         .then(function (response) {
             // Parse and Display The Events
             console.log("LOCAL CURRENT EVENTS", response);
-            let events = parseEvents(response);
-            return events;
-        }).then(function (events) {
+            user.events = parseEvents(response);
+            user.lastSearch = user.location.city;
             labelStatusEl.textContent = " "; // Update the status label
-            user.events = events; // Cache the area events
             user.zoom = ZOOM_LOCAL;
             user.caption = "Local Area Events";
             displayEvents(); // Display the Events on the Page
@@ -663,7 +660,7 @@ function parseTracks(topTracks) {
 // Update the HTML to display event info
 // Display a single page of events on the page
 //=====================================================================
-function displayEvents(displayNewDayHeading = true) {
+function displayEvents(redrawMap = true) {
     let events = user.events;
     let limit = MAX_DISPLAY_RESULTS;
 
@@ -715,6 +712,7 @@ function displayEvents(displayNewDayHeading = true) {
 
         // if displayNewDayHeading is enabled...
         // Add a header div when we encounter a new day in the listings
+        const displayNewDayHeading = true;
         if (displayNewDayHeading && lastOutputTime !== event.startDate) {
             let dayMarkerContainer = createEl("div", "dayMarker");
             eventListEl.appendChild(dayMarkerContainer);
@@ -731,7 +729,7 @@ function displayEvents(displayNewDayHeading = true) {
 
     // Update the paging to reflect the new event list
     updatePaging();
-    drawMap(user.location, pageEvents);
+    if (redrawMap) drawMap(user.location, pageEvents);
 }
 
 //=====================================================================

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -166,8 +166,7 @@ pagePrevEl.addEventListener("click", function (event) {
 
 // pageGo click event handler
 pageGoEl.addEventListener("click", function (event) {
-    pageInputEl.value = parseInt(pageInputEl.value);
-    user.page = pageInputEl.value;
+    user.page = parseInt(pageInputEl.value);
     pageInputEl.value = "";
     loadPage();
 });
@@ -226,8 +225,8 @@ function loadPage() {
         user.page = 1;
         pageInputEl.value = user.page;
         return;
-    } else if ((user.page - 1) * MAX_DISPLAY_RESULTS >= user.totalEvents) {
-        user.page = Math.ceil(user.totalEvents / MAX_DISPLAY_RESULTS);
+    } else if ((user.page - 1) * MAX_DISPLAY_RESULTS >= user.events.length) {
+        user.page = Math.ceil(user.events.length / MAX_DISPLAY_RESULTS);
         pageInputEl.value = user.page;
         return;
     }
@@ -285,6 +284,7 @@ function getLocationPromise() {
 //=====================================================================
 // Get a Promise to retrieve the Events for an Artist
 //  artist = artist object
+//  pageIndex (zero-based)
 //=====================================================================
 function getArtistEventsPromise(artist, pageIndex=0) {
     let latlng = "latlong=" + user.location.lat + "," + user.location.lon;
@@ -303,6 +303,7 @@ function getArtistEventsPromise(artist, pageIndex=0) {
 
 //=====================================================================
 // Get a Promise to retrieve the Events for a Location
+//  pageIndex (zero-based)
 //=====================================================================
 function getLocalEventsPromise(pageIndex=0) {
     const radiusMiles = MAX_DISTANCE_LOCAL;
@@ -545,7 +546,8 @@ function updatePaging() {
     if (isDisplayed) {
         // Set the Visibility of Next/Prev based on event list size and page
         let isNextEnabled = (user.page * MAX_DISPLAY_RESULTS < events.length);
-        let isPrevEnabled = (user.page !== 1);
+        let isPrevEnabled = (user.page != 1);
+        console.log(user.page, isPrevEnabled);
         // Set the Next Button
         if (isNextEnabled) {
             pageNextEl.removeAttribute("disabled", "");

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
 
                     <!-- Top Tracks Here -->
                     <div id="topBox" class="content is-outlined has-text-left box">
-                        <h1 id="topHead" class="title is-3"></h1>
+                        <h1 id="topHead" class="title is-4"></h1>
                         <h3 id="topTrackName"></h3>
                         <div id="topVideo">
                         </div>


### PR DESCRIPTION
Fixed an issue where we are getting page 1 first when we need to get page 0.
Retrieve all results before displaying.  This allows for the user to access all results, not only the first 200.
